### PR TITLE
fix(video): ensure minimumFileSizeForCompress is still used even if 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-prettier": "^3.1.3",
     "husky": "^4.2.5",
     "jest": "^26.0.1",
+    "metro-react-native-babel-preset": "^0.66.2",
     "pod-install": "^0.1.0",
     "prettier": "^2.0.5",
     "react": "^17.0.2",
@@ -89,6 +90,9 @@
     "modulePathIgnorePatterns": [
       "<rootDir>/example/node_modules",
       "<rootDir>/lib/"
+    ],
+    "setupFiles": [
+      "./src/__mocks__/VideoCompressor.ts"
     ]
   },
   "husky": {

--- a/src/Video/index.tsx
+++ b/src/Video/index.tsx
@@ -152,9 +152,9 @@ const Video: VideoCompressorType = {
       } else {
         modifiedOptions.maxSize = 640;
       }
-      if (options?.minimumFileSizeForCompress) {
+      if (options?.minimumFileSizeForCompress !== undefined) {
         modifiedOptions.minimumFileSizeForCompress =
-          options?.minimumFileSizeForCompress;
+          options.minimumFileSizeForCompress;
       }
       const result = await NativeVideoCompressor.compress(
         fileUrl,

--- a/src/__mocks__/VideoCompressor.ts
+++ b/src/__mocks__/VideoCompressor.ts
@@ -1,0 +1,5 @@
+import { NativeModules } from 'react-native';
+
+NativeModules.VideoCompressor = {
+  compress: jest.fn(),
+};

--- a/src/__tests__/Video.test.tsx
+++ b/src/__tests__/Video.test.tsx
@@ -1,0 +1,26 @@
+import Video from '../Video/index';
+import { NativeModules } from 'react-native';
+
+jest.mock(
+  '../../node_modules/react-native/Libraries/EventEmitter/NativeEventEmitter'
+);
+
+jest.mock('uuid', () => ({
+  v4: () => 'foouuid',
+}));
+
+describe('Video Compression', () => {
+  it('Includes the minimumFileSizeForCompress option even if it is 0', () => {
+    Video.compress('fooUrl.mp4', { minimumFileSizeForCompress: 0 });
+
+    expect(NativeModules.VideoCompressor.compress).toHaveBeenCalledWith(
+      'fooUrl.mp4',
+      {
+        compressionMethod: 'manual',
+        minimumFileSizeForCompress: 0,
+        maxSize: 640,
+        uuid: 'foouuid',
+      }
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6621,7 +6621,7 @@ metro-minify-uglify@0.66.2:
   dependencies:
     uglify-es "^3.1.9"
 
-metro-react-native-babel-preset@0.66.2:
+metro-react-native-babel-preset@0.66.2, metro-react-native-babel-preset@^0.66.2:
   version "0.66.2"
   resolved "https://registry.yarnpkg.com/metro-react-native-babel-preset/-/metro-react-native-babel-preset-0.66.2.tgz#fddebcf413ad4ea617d4f47f7c1da401052de734"
   integrity sha512-H/nLBAz0MgfDloSe1FjyH4EnbokHFdncyERvLPXDACY3ROVRCeUyFNo70ywRGXW2NMbrV4H7KUyU4zkfWhC2HQ==


### PR DESCRIPTION
Previously if a value of 0 was passed for `minimumFileSizeForCompress`, the parameter would be ignored, as it would evaluate falsy and appear as nonexistent.  This adds an explicit check for undefined, and adds a test to ensure it gets properly passed along.