### PR TITLE
Fix divide by zero error (iOS)

### DIFF
--- a/ios/Video/VideoCompressor.swift
+++ b/ios/Video/VideoCompressor.swift
@@ -207,7 +207,7 @@ func makeValidUri(filePath: String) -> String {
     }
     if(fileSize>minimumFileSizeForCompress)
     {
-        if(options["compressionMethod"] as! String== "auto")
+        if(options["compressionMethod"] as! String == "auto")
         {
             autoCompressionHelper(url: url, options:options) { progress in
                 onProgress(progress)


### PR DESCRIPTION
Hi, I encountered a crash when compressing a small video. Here is my fix.

Xcode debugger indicated that the error comes from a "divide by zero" in the `minBitrate` expression. When the `width * height` is larger than `1280 * 720`, the integer division will yield 0, which causes the crash.

Another issue I found, the `maxSize` option is ignored in the manual compression method. It seems hardcoded to 1920. I changed it to actually read the option. I assume the `maxSize` has a default value coming from JS like the auto method.