### PR TITLE
getVideoTrack(): return the first video track in the asset when the number of tracks is greater than 2

### DIFF
--- a/ios/Video/VideoCompressor.swift
+++ b/ios/Video/VideoCompressor.swift
@@ -400,17 +400,8 @@ func makeValidUri(filePath: String) -> String {
     }
     
     func getVideoTrack(asset: AVAsset) -> AVAssetTrack {
-        var videoTrackIndex: Int = 0;
-        let trackLength = asset.tracks.count;
-        if(trackLength==2)
-        {
-            if(asset.tracks[0].mediaType.rawValue=="soun")
-            {
-                videoTrackIndex=1;
-            }
-        }
-        let track = asset.tracks[videoTrackIndex];
-        return track;
+        let tracks = asset.tracks(withMediaType: AVMediaType.video)
+        return tracks[0];
         }
     
     }


### PR DESCRIPTION
Hi, this change addresses issue https://github.com/Shobbak/react-native-compressor/issues/93 where my iOS app crashes when attempting to compress a video being shared from the iOS Photos app.

## Summary

The number of tracks in the video asset coming from the Photos app (i.e. Camera Roll) through an iOS Share Extension seems to be 5: one audio, one video and three metadata. The `getVideoTrack()` function in `VideoCompressor.swift` returns the first track (of any type) by default if the number of tracks is different than 2. This makes the function return the audio track for videos with more than 2 tracks. This is the reason the compression fails in my case. This PR modifies the function to return the first video track it finds, irrespective of the number of tracks in the asset.

## Changelog

File: VideoCompressor.swift
Function: getVideoTrack(asset: AVAsset) -> AVAssetTrack

## Test Plan

This PR was tested on a physical iPhone 7 using the test app at https://github.com/alariej/sharedvideocompress, by sharing videos via a Share Extension, using either the Photos app or the Files app.
