### PR TITLE
fix: allow maxSize option for manual compression (iOS)

### DIFF
--- a/ios/Video/VideoCompressor.swift
+++ b/ios/Video/VideoCompressor.swift
@@ -319,7 +319,7 @@ func makeValidUri(filePath: String) -> String {
         var width = Float(abs(videoSize.width))
         var height = Float(abs(videoSize.height))
         let isPortrait = height > width
-        let maxSize = Float(1920);
+        let maxSize = (options["maxSize"] as! Float?) ?? Float(1920);
         if(isPortrait && height > maxSize){
           width = (maxSize/height)*width
           height = maxSize


### PR DESCRIPTION
## Summary

Allow the maxSize option to be used inside the `manualCompressionHelper` for iOS

fixes #130

## Changelog

File: `VideoCompressor.swift`
Function: `manualCompressionHelper(url: URL, options: [String: Any], onProgress: @escaping (Float) -> Void,  onCompletion: @escaping (URL) -> Void, onFailure: @escaping (Error) -> Void)`

## Test Plan

This is a trivial 1-line change. If there is a problem with it, it will be caught by the compiler or this PR.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
