### PR TITLE
Fixing '"new NativeEventEmitter()" was called with a non-null argument...'

### DIFF
--- a/android/src/main/java/com/reactnativecompressor/Video/VideoModule.java
+++ b/android/src/main/java/com/reactnativecompressor/Video/VideoModule.java
@@ -110,4 +110,14 @@ public class  VideoModule extends ReactContextBaseJavaModule {
       promise.reject(ex);
     }
   }
+
+  @ReactMethod
+  public void addListener(String eventName) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
 }


### PR DESCRIPTION
## Summary

Whenever I try to compress an image on Android, two warning are triggered:
1. \`new NativeEventEmitter()\` was called with a non-null argument without the required \`addListener\` method.
2. \`new NativeEventEmitter()\` was called with a non-null argument without the required \`removeListeners\` method.

After a while looking for a solution on the internet, I found the the fix mentioned on #132 and managed to solve the problem. So as no one took action about that, I decided to create this PR.

## Changelog

File: android/src/main/java/com/reactnativecompressor/Video/VideoModule.java
Class: VideoModule

_Add the two following methods to the end of the_ **VideoModule** _class:_

```java
@ReactMethod
public void addListener(String eventName) {
  // Keep: Required for RN built in Event Emitter Calls.
}

@ReactMethod
public void removeListeners(Integer count) {
  // Keep: Required for RN built in Event Emitter Calls.
}
```

## Test Plan

In my case, I was getting the following warnings while trying to compress an image using the `Image.compress(imagePath, { compressionMethod: 'auto' })` method:

![Screenshot_20230310-010618_AthosTrackingApp](https://user-images.githubusercontent.com/50087319/224221431-4ebe71b9-73aa-40d0-803a-ef97833db692.jpg)
![Screenshot_20230310-010627_AthosTrackingApp](https://user-images.githubusercontent.com/50087319/224221469-3b02753c-0242-428d-b22a-e0154dd0fb12.jpg)

The images were taken from the [react-native-image-picker](https://github.com/react-native-image-picker/react-native-image-picker) library.

After doing the changes mentioned in the changelog, I got rid of the warnings.

## Environment

### Platform
Android 12

### Device
Samsung Galaxy S10 Lite

### React Native
0.70.6

### React Native Compressor
1.6.1


