### PR TITLE
refactor: remove unused AssetsLibrary import from VideoMain.swift

### DIFF
--- a/ios/Video/VideoMain.swift
+++ b/ios/Video/VideoMain.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AssetsLibrary
 import AVFoundation
 import Photos
 import MobileCoreServices


### PR DESCRIPTION
Because AssetsLibrary is removed in iOS 26
