### PR TITLE
[Fix]: Properly handle base64 image compression for iOS

### DIFF
--- a/ios/Image/ImageMain.swift
+++ b/ios/Image/ImageMain.swift
@@ -7,18 +7,29 @@
 
 import Foundation
 class ImageMain {
-    static func image_compress(_ imagePath: String, optionMap: NSDictionary, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    static func image_compress(_ value: String, optionMap: NSDictionary, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
             let options = ImageCompressorOptions.fromDictionary(optionMap as! [String : Any])
-            ImageCompressor.getAbsoluteImagePath(imagePath, options: options) { absoluteImagePath in
+            
+            if options.input != InputType.base64 {
+                ImageCompressor.getAbsoluteImagePath(value, options: options) { absoluteImagePath in
+                    if options.autoCompress {
+                        let result = ImageCompressor.autoCompressHandler(imagePath: absoluteImagePath, base64: nil, options: options)
+                        resolve(result)
+                    } else {
+                        let result = ImageCompressor.manualCompressHandler(imagePath: absoluteImagePath, base64: nil, options: options)
+                        resolve(result)
+                    }
+                    MediaCache.removeCompletedImagePath(absoluteImagePath)
+                }
+            } else {
                 if options.autoCompress {
-                    let result = ImageCompressor.autoCompressHandler(absoluteImagePath, options: options)
+                    let result = ImageCompressor.autoCompressHandler(imagePath: nil, base64: value, options: options)
                     resolve(result)
                 } else {
-                    let result = ImageCompressor.manualCompressHandler(absoluteImagePath, options: options)
+                    let result = ImageCompressor.manualCompressHandler(imagePath: nil, base64: value, options: options)
                     resolve(result)
                 }
-                MediaCache.removeCompletedImagePath(absoluteImagePath)
             }
         } catch {
             reject(error.localizedDescription, error.localizedDescription, nil)

--- a/ios/Utils/Utils.swift
+++ b/ios/Utils/Utils.swift
@@ -104,9 +104,9 @@ class Utils {
         }
     }
     
-    static func getfileSizeInBytes(forURL url: Any) -> Double {
+    static func getfileSizeInBytes(forURL url: Any) -> Int {
         var fileURL: URL?
-        var fileSize: Double = 0.0
+        var fileSize: Int = 0
         
         if (url is URL) {
             let urlWithSlash = Utils.slashifyFilePath(path: (url as? URL)?.absoluteString)
@@ -118,11 +118,12 @@ class Utils {
             return fileSize
         }
         
-        var fileSizeValue = 0.0
+        var fileSizeValue = 0
         
-        try? fileSizeValue = (fileURL?.resourceValues(forKeys: [URLResourceKey.fileSizeKey]).allValues.first?.value as! Double?)!
-        if fileSizeValue > 0.0 {
-            fileSize = Double(fileSizeValue)
+        try? fileSizeValue = (fileURL?.resourceValues(forKeys: [URLResourceKey.fileSizeKey]).allValues.first?.value as! Int)
+        
+        if fileSizeValue > 0 {
+            fileSize = fileSizeValue
         }
         
         return fileSize


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When calling `Compressor.compress()` with a base64 input on iOS, the ImageCompressor module handles it as a URL, and therefore prepends `file:///` to it before initializing a Swift `Data` object, which causes the compression process to fail.

This PR modifies the ImageCompressor class to call `getAbsoluteImagePath` only if  the compressor's `input` option is set to anything other than `base64`. If the input is `base64`, it will be handled by automatic/manual handlers as-is and will be properly mapped to `ImageUI`.

The rest of the compression process that was expecting the input to always be a URL has been modified to handle the input polymorphism.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

- No user-facing changes to the public API.
- Image compression now handles base64 input for both automatic and manual compression methods.

## Issues

Fixes https://github.com/numandev1/react-native-compressor/issues/299