### PR TITLE
Fix image orientation handling in decode and load methods

### DIFF
--- a/android/src/main/java/com/reactnativecompressor/Image/ImageCompressor.kt
+++ b/android/src/main/java/com/reactnativecompressor/Image/ImageCompressor.kt
@@ -47,13 +47,15 @@ object ImageCompressor {
 
     fun decodeImage(value: String?): Bitmap {
         val data = Base64.decode(value, Base64.DEFAULT)
-        return BitmapFactory.decodeByteArray(data, 0, data.size)
+        val bmp = BitmapFactory.decodeByteArray(data, 0, data.size)
+        return correctImageOrientation(bmp, filePath) ?: bmp
     }
 
     fun loadImage(value: String?): Bitmap {
         val uri = Uri.parse(value)
         val filePath = uri.path
-        return BitmapFactory.decodeFile(filePath)
+        val bmp = BitmapFactory.decodeFile(filePath)
+        return correctImageOrientation(bmp, filePath) ?: bmp
     }
 
     fun copyExifInfo(imagePath:String, outputUri:String){


### PR DESCRIPTION
## Summary

The image is oriented incorrectly after manualCompressImage. Therefore, correctImageOrientation must be called when loadingImage and decodeImage.

## Changelog
- Ensure correct image orientation when decoding and loading images.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
