### PR TITLE
fix: OOM crash

### DIFF
--- a/ios/Utils/Utils.swift
+++ b/ios/Utils/Utils.swift
@@ -70,6 +70,8 @@ class Utils {
                    let fileSize = attrs[.size] as? UInt64 {
                     let fileSizeString = String(fileSize)
                     resolve(fileSizeString)
+                } else {
+                    reject("FILE_SIZE_ERROR", "Failed to get file size for path: \(filePath)", nil)
                 }
             }
         } catch {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

We were facing OOM crash.

It happens because we load whole file into memory to get its size:

```swift
let imageData = NSData(contentsOfFile: absoluteImagePath)!
```

In this PR I'm using `CGImageSourceCreateWithURL` to avoid loading whole file into memory until it's really needed.

Also added more guards and removed `!` operators (which eventually may lead to silent crashes and don't propagate error to JS).

## Changelog

[ios] [bugfix] - use `CGImageSourceCreateWithURL` to avoid OOM crash

## Test Plan

Try to load 1000 RAW images simultaneosly and get size of all of them via `Promise.all([getImageMetadata...])`
