### PR TITLE
Triage issues and harden high-resolution video compression paths

### DIFF
--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -1,0 +1,88 @@
+# Upstream issue triage
+
+Audited against `numandev1/react-native-compressor` open issues on 2026-04-27 and compared with the current tree in this fork.
+
+Legend:
+- `real` = credible library issue
+- `fixed here` = addressed in this branch
+- `duplicate` = same root cause as another issue
+- `stale` = issue targets code that is no longer present in the current tree
+- `needs info` = not enough detail to prove a library defect
+- `feature` = request, not a bug
+- `not a bug` = current expectation does not match exposed API
+
+| Issue | Triage | Notes |
+| --- | --- | --- |
+| #390 | not a bug | Reports `start` / `end` time behavior for video compression, but the current public video API does not expose trim parameters. |
+| #387 | needs info | Gradle binary store corruption looks environment-specific; report does not isolate a library code change. |
+| #384 | needs info | Performance question, not a reproducible defect report. |
+| #383 | real | Android transcode pipeline can blow up on pathological audio metadata (`uint32 overflow`). This branch improves failure handling so it rejects instead of silently succeeding. |
+| #382 | needs info | “Works in dev, fails in prod” has no logs or repro app. |
+| #381 | feature | Nitro Modules migration request. |
+| #380 | real, fixed here | Android manual compression could produce invalid tiny files when `maxSize` generated odd dimensions or invalid output. This branch normalizes dimensions and rejects invalid output files. |
+| #377 | real, fixed here | Android auto compression was overly aggressive. This branch switches to adaptive bitrate + frame-rate caps for high-res sources. |
+| #376 | duplicate | Same symptom family as #380 / #369: invalid tiny Android outputs on specific devices. |
+| #375 | real, fixed here | Quality complaint is consistent with the old hard bitrate cap. Adaptive bitrate selection in this branch directly targets it. |
+| #371 | duplicate | Likely another Android video transcode failure in the same cluster as #343 / #380 / #376. |
+| #370 | stale | Current tree no longer imports `AssetsLibrary`; this is already gone. |
+| #369 | real | “Playable only in VLC” is credible output-container compatibility fallout; likely same Android transcode/output-validation cluster as #380 / #376. |
+| #367 | stale | Same `AssetsLibrary` removal request as #370 / #362; already addressed in current sources. |
+| #366 | real | `libandroidlame.so` 16 KB page-size warning is a real Android dependency issue, but separate from video compression. |
+| #365 | real, fixed here | Android parsed bitrate metadata as `Int` and could overflow on bogus sentinel values. This branch now clamps metadata safely. |
+| #364 | real | Manual compression crash report is credible; likely same manual-path sizing/metadata weaknesses addressed here, but no sample was attached. |
+| #363 | real, fixed here | iOS assumed a video track existed and could crash on audio-only MP4 files. This branch now guards that path. |
+| #362 | stale | Another `AssetsLibrary` build failure that no longer matches the current tree. |
+| #358 | feature | Live photo optimization request. |
+| #356 | real, fixed here | Android AGP 8+ `BuildConfig` generation issue. This branch enables `buildConfig` in the library Gradle file. |
+| #354 | stale | Old Android build failure references the previous `AndroidLame-kotlin` dependency coordinates, which are no longer in this tree. |
+| #353 | feature | Audio speed-up request. |
+| #352 | real | Thumbnail generation failing on some videos is plausible and has a sample, but was not investigated in this pass. |
+| #348 | stale | Report targets `1.11.0` Gradle sync behavior with minimal details; no matching current-tree defect was found. |
+| #347 | real | Image quality parameter complaint is credible and independent of the video work in this branch. |
+| #345 | stale | Current tree has only one TurboModule spec (`src/Spec/NativeCompressor.ts`); the duplicate-spec issue no longer matches HEAD. |
+| #343 | real, fixed here | Repeated 4k Android compression failures line up with old manual sizing/bitrate behavior. This branch reworks the compression profile for high-res inputs. |
+| #318 | stale | Old dependency-resolution issue references outdated dependency coordinates and repository/network failures. |
+| #308 | duplicate | Broad “sometimes compresses, sometimes not” report fits the Android video-quality/output cluster but lacks a repro sample. |
+| #302 | needs info | Slow compression is a product concern, but the report is only a timing complaint with no reproducible defect. |
+| #263 | real | iOS background upload returning an empty response body is a credible platform-specific bug outside this video-focused change set. |
+
+## Main clusters
+
+### Android video compression cluster
+
+These are all likely manifestations of the same area and should be tracked together:
+
+- #343
+- #375
+- #376
+- #377
+- #380
+- #369
+- #371
+- #308
+
+This branch addresses the most obvious causes in that cluster:
+
+- odd output dimensions
+- brittle bitrate heuristics
+- no frame-rate cap for high-resolution sources
+- success being reported for invalid output files
+- overflow-prone metadata parsing
+
+### Already obsolete issues
+
+These should be closed upstream unless a current repro still exists on the latest code:
+
+- #345
+- #354
+- #362
+- #367
+- #370
+- #318
+
+## Minor fixes made in this branch
+
+- Android: enable `buildConfig` generation for AGP 8+ builds
+- Android: clamp metadata parsing and reject invalid transcode output
+- Android: adaptive video compression profile for high-resolution inputs
+- iOS: guard missing video tracks and use the same adaptive sizing/bitrate strategy

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,6 +67,9 @@ android {
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
   }
+  buildFeatures {
+    buildConfig true
+  }
   buildTypes {
     release {
       minifyEnabled false

--- a/android/src/main/java/com/reactnativecompressor/Utils/Utils.kt
+++ b/android/src/main/java/com/reactnativecompressor/Utils/Utils.kt
@@ -29,12 +29,12 @@ object Utils {
     }
 
     @JvmStatic
-    fun compressVideo(srcPath: String, destinationPath: String, resultWidth: Int, resultHeight: Int, videoBitRate: Float, uuid: String,progressDivider:Int, promise: Promise, reactContext: ReactApplicationContext) {
+    fun compressVideo(srcPath: String, destinationPath: String, resultWidth: Int, resultHeight: Int, videoBitRate: Float, frameRate: Int, uuid: String,progressDivider:Int, promise: Promise, reactContext: ReactApplicationContext) {
       val currentVideoCompression = intArrayOf(0)
       val videoCompressorClass: VideoCompressorClass? = VideoCompressorClass(reactContext);
       compressorExports[uuid] = videoCompressorClass
       videoCompressorClass?.start(
-        srcPath, destinationPath, resultWidth, resultHeight, videoBitRate.toInt(),
+        srcPath, destinationPath, resultWidth, resultHeight, videoBitRate.toInt(), frameRate,
         listener = object : CompressionListener {
           override fun onProgress(index: Int, percent: Float) {
             if (percent <= 100) {

--- a/android/src/main/java/com/reactnativecompressor/Video/AutoVideoCompression.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/AutoVideoCompression.kt
@@ -10,7 +10,6 @@ import java.io.File
 
 object AutoVideoCompression {
     fun createCompressionSettings(fileUrl: String?, options: VideoCompressorHelper, promise: Promise, reactContext: ReactApplicationContext?) {
-        val maxSize = options.maxSize
         val minimumFileSizeForCompress = options.minimumFileSizeForCompress
         try {
             val uri = Uri.parse(fileUrl)
@@ -22,42 +21,38 @@ object AutoVideoCompression {
             val sizeInMb = sizeInBytes / (1024 * 1024)
             if (sizeInMb > minimumFileSizeForCompress) {
                 val destinationPath = generateCacheFilePath("mp4", reactContext!!)
-                val actualHeight = metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)!!.toInt()
-                val actualWidth = metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)!!.toInt()
-                val bitrate = metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE)!!.toInt()
-                val scale = if (actualWidth > actualHeight) maxSize / actualWidth else maxSize / actualHeight
-                val resultWidth = Math.round(actualWidth * Math.min(scale, 1f) / 2) * 2
-                val resultHeight = Math.round(actualHeight * Math.min(scale, 1f) / 2) * 2
-                val videoBitRate = makeVideoBitrate(
-                  actualHeight, actualWidth,
-                  bitrate,
-                  resultHeight, resultWidth
-                ).toFloat()
-                compressVideo(srcPath!!, destinationPath, resultWidth, resultHeight, videoBitRate, options.uuid!!,options.progressDivider!!, promise, reactContext)
+                val actualHeight = VideoCompressorHelper.getMetadataInt(metaRetriever, MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
+                val actualWidth = VideoCompressorHelper.getMetadataInt(metaRetriever, MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
+                val bitrate = VideoCompressorHelper.getMetadataInt(metaRetriever, MediaMetadataRetriever.METADATA_KEY_BITRATE)
+                val frameRate = VideoCompressorHelper.getMetadataInt(metaRetriever, MediaMetadataRetriever.METADATA_KEY_CAPTURE_FRAMERATE)
+                if (actualHeight <= 0 || actualWidth <= 0) {
+                    promise.reject(Throwable("Failed to read the input video dimensions"))
+                    return
+                }
+                val profile = VideoCompressionProfileFactory.createAuto(
+                    sourceWidth = actualWidth,
+                    sourceHeight = actualHeight,
+                    sourceBitrate = bitrate,
+                    sourceFrameRate = frameRate,
+                    maxSize = options.maxSize,
+                )
+                compressVideo(
+                    srcPath!!,
+                    destinationPath,
+                    profile.width,
+                    profile.height,
+                    profile.bitrate.toFloat(),
+                    profile.frameRate,
+                    options.uuid!!,
+                    options.progressDivider!!,
+                    promise,
+                    reactContext,
+                )
             } else {
                 promise.resolve(fileUrl)
             }
         } catch (ex: Exception) {
             promise.reject(ex)
         }
-    }
-
-    fun makeVideoBitrate(originalHeight: Int, originalWidth: Int, originalBitrate: Int, height: Int, width: Int): Int {
-        val compressFactor = 0.8f
-        val minCompressFactor = 0.8f
-        val maxBitrate = 1669000
-        var remeasuredBitrate = (originalBitrate / Math.min(originalHeight / height.toFloat(), originalWidth / width.toFloat())).toInt()
-        remeasuredBitrate = (remeasuredBitrate * compressFactor).toInt()
-        val minBitrate = (getVideoBitrateWithFactor(minCompressFactor) / (1280f * 720f / (width * height))).toInt()
-        if (originalBitrate < minBitrate) {
-            return remeasuredBitrate
-        }
-        return if (remeasuredBitrate > maxBitrate) {
-            maxBitrate
-        } else Math.max(remeasuredBitrate, minBitrate)
-    }
-
-    private fun getVideoBitrateWithFactor(f: Float): Int {
-        return (f * 2000f * 1000f * 1.13f).toInt()
     }
 }

--- a/android/src/main/java/com/reactnativecompressor/Video/VideoCompressionProfile.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/VideoCompressionProfile.kt
@@ -1,0 +1,144 @@
+package com.reactnativecompressor.Video
+
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+data class VideoCompressionProfile(
+    val width: Int,
+    val height: Int,
+    val bitrate: Int,
+    val frameRate: Int,
+)
+
+object VideoCompressionProfileFactory {
+    private const val DEFAULT_FRAME_RATE = 30
+
+    fun createAuto(
+        sourceWidth: Int,
+        sourceHeight: Int,
+        sourceBitrate: Int,
+        sourceFrameRate: Int,
+        maxSize: Float,
+    ): VideoCompressionProfile {
+        val dimensions = scaleWithin(sourceWidth, sourceHeight, maxSize.roundToInt())
+        val frameRate = normalizeFrameRate(sourceFrameRate)
+        val bitrate = estimateBitrate(
+            sourceWidth = sourceWidth,
+            sourceHeight = sourceHeight,
+            sourceBitrate = sourceBitrate,
+            sourceFrameRate = sourceFrameRate,
+            targetWidth = dimensions.first,
+            targetHeight = dimensions.second,
+            targetFrameRate = frameRate,
+        )
+
+        return VideoCompressionProfile(
+            width = dimensions.first,
+            height = dimensions.second,
+            bitrate = bitrate,
+            frameRate = frameRate,
+        )
+    }
+
+    fun createManual(
+        sourceWidth: Int,
+        sourceHeight: Int,
+        sourceBitrate: Int,
+        sourceFrameRate: Int,
+        maxSize: Float,
+        requestedBitrate: Float,
+    ): VideoCompressionProfile {
+        val dimensions = scaleWithin(sourceWidth, sourceHeight, maxSize.roundToInt())
+        val frameRate = normalizeFrameRate(sourceFrameRate)
+        val bitrate = if (requestedBitrate > 0f) {
+            requestedBitrate.roundToInt().coerceAtLeast(1)
+        } else {
+            estimateBitrate(
+                sourceWidth = sourceWidth,
+                sourceHeight = sourceHeight,
+                sourceBitrate = sourceBitrate,
+                sourceFrameRate = sourceFrameRate,
+                targetWidth = dimensions.first,
+                targetHeight = dimensions.second,
+                targetFrameRate = frameRate,
+            )
+        }
+
+        return VideoCompressionProfile(
+            width = dimensions.first,
+            height = dimensions.second,
+            bitrate = bitrate,
+            frameRate = frameRate,
+        )
+    }
+
+    fun normalizeDimension(value: Int): Int {
+        val positive = value.coerceAtLeast(2)
+        return if (positive % 2 == 0) positive else positive - 1
+    }
+
+    private fun scaleWithin(sourceWidth: Int, sourceHeight: Int, requestedMaxSize: Int): Pair<Int, Int> {
+        val safeWidth = normalizeDimension(sourceWidth)
+        val safeHeight = normalizeDimension(sourceHeight)
+        val longSide = max(safeWidth, safeHeight)
+        val boundedMaxSize = requestedMaxSize.coerceAtLeast(2)
+
+        if (longSide <= boundedMaxSize) {
+            return Pair(safeWidth, safeHeight)
+        }
+
+        val scale = boundedMaxSize.toFloat() / longSide.toFloat()
+        val width = normalizeDimension((safeWidth * scale).roundToInt())
+        val height = normalizeDimension((safeHeight * scale).roundToInt())
+        return Pair(width, height)
+    }
+
+    private fun normalizeFrameRate(sourceFrameRate: Int): Int {
+        if (sourceFrameRate <= 0) {
+            return DEFAULT_FRAME_RATE
+        }
+
+        return sourceFrameRate.coerceIn(1, DEFAULT_FRAME_RATE)
+    }
+
+    private fun estimateBitrate(
+        sourceWidth: Int,
+        sourceHeight: Int,
+        sourceBitrate: Int,
+        sourceFrameRate: Int,
+        targetWidth: Int,
+        targetHeight: Int,
+        targetFrameRate: Int,
+    ): Int {
+        val targetLongSide = max(targetWidth, targetHeight)
+        val floor = when {
+            targetLongSide >= 1920 -> 4_000_000
+            targetLongSide >= 1280 -> 2_200_000
+            targetLongSide >= 960 -> 1_600_000
+            targetLongSide >= 720 -> 1_200_000
+            else -> 850_000
+        }
+        val ceiling = when {
+            targetLongSide >= 1920 -> 8_000_000
+            targetLongSide >= 1280 -> 5_000_000
+            targetLongSide >= 960 -> 3_500_000
+            targetLongSide >= 720 -> 2_500_000
+            else -> 1_500_000
+        }
+
+        if (sourceBitrate <= 0) {
+            return floor
+        }
+
+        val sourcePixels = sourceWidth.toLong() * sourceHeight.toLong()
+        val targetPixels = targetWidth.toLong() * targetHeight.toLong()
+        val pixelRatio = if (sourcePixels == 0L) 1.0 else targetPixels.toDouble() / sourcePixels.toDouble()
+        val sourceFps = max(sourceFrameRate, 1)
+        val frameRateRatio = targetFrameRate.toDouble() / sourceFps.toDouble()
+        val scaledBitrate = (sourceBitrate * pixelRatio * max(frameRateRatio, 0.85)).roundToInt()
+        val sourceCap = (sourceBitrate * 0.95).roundToInt().coerceAtLeast(floor)
+
+        return scaledBitrate.coerceAtLeast(floor).coerceAtMost(min(ceiling, sourceCap))
+    }
+}

--- a/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/VideoCompressorClass.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/VideoCompressorClass.kt
@@ -24,6 +24,7 @@ class VideoCompressorClass(private val context: ReactApplicationContext) {
     outputWidth: Int,
     outputHeight: Int,
     bitrate: Int,
+    frameRate: Int,
     listener: CompressionListener,
   ) {
     val uris = mutableListOf<Uri>()
@@ -36,6 +37,7 @@ class VideoCompressorClass(private val context: ReactApplicationContext) {
       outputWidth,
       outputHeight,
       bitrate,
+      frameRate,
       listener,
       destPath
     )
@@ -52,6 +54,7 @@ class VideoCompressorClass(private val context: ReactApplicationContext) {
     outputWidth: Int,
     outputHeight: Int,
     bitrate: Int,
+    frameRate: Int,
     listener: CompressionListener,
     destPath: String
   ) {
@@ -74,6 +77,7 @@ class VideoCompressorClass(private val context: ReactApplicationContext) {
             outputWidth,
             outputHeight,
             bitrate,
+            frameRate,
             listener,
           )
 
@@ -96,6 +100,7 @@ class VideoCompressorClass(private val context: ReactApplicationContext) {
     outputWidth: Int,
     outputHeight: Int,
     bitrate: Int,
+    frameRate: Int,
     listener: CompressionListener,
   ): Result = withContext(Dispatchers.Default) {
     return@withContext compressVideo(
@@ -107,6 +112,7 @@ class VideoCompressorClass(private val context: ReactApplicationContext) {
       outputWidth,
       outputHeight,
       bitrate,
+      frameRate,
       object : CompressionProgressListener {
         override fun onProgressChanged(index: Int, percent: Float) {
           listener.onProgress(index, percent)

--- a/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/compressor/Compressor.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/compressor/Compressor.kt
@@ -54,6 +54,7 @@ object Compressor {
     outputWidth: Int,
     outputHeight: Int,
     outputBitrate: Int,
+    outputFrameRate: Int,
     listener: CompressionProgressListener,
   ): Result = withContext(Dispatchers.Default) {
 
@@ -123,6 +124,7 @@ object Compressor {
       newHeight!!,
       destination,
       newBitrate,
+      outputFrameRate,
       streamableFile,
       false,
       extractor,
@@ -140,6 +142,7 @@ object Compressor {
     newHeight: Int,
     destination: String,
     newBitrate: Int,
+    outputFrameRate: Int,
     streamableFile: String?,
     disableAudio: Boolean,
     extractor: MediaExtractor,
@@ -178,6 +181,7 @@ object Compressor {
           inputFormat,
           outputFormat,
           newBitrate,
+          outputFrameRate,
         )
 
         val decoder: MediaCodec
@@ -374,7 +378,7 @@ object Compressor {
                         }
           }
 
-        } catch (exception: Exception) {
+        } catch (exception: Throwable) {
           printException(exception)
           return Result(id, success = false, failureMessage = exception.message)
         }
@@ -400,12 +404,14 @@ object Compressor {
         extractor.release()
         try {
           mediaMuxer.finishMovie()
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
           printException(e)
+          return Result(id, success = false, failureMessage = e.message ?: "Failed to finalize compressed video")
         }
 
-      } catch (exception: Exception) {
+      } catch (exception: Throwable) {
         printException(exception)
+        return Result(id, success = false, failureMessage = exception.message)
       }
 
       var resultFile = cacheFile
@@ -422,6 +428,13 @@ object Compressor {
         } catch (e: Exception) {
           printException(e)
         }
+      }
+      if (!resultFile.exists() || resultFile.length() <= 32) {
+        return Result(
+          id,
+          success = false,
+          failureMessage = "Compressed video output is invalid"
+        )
       }
       return Result(
         id,

--- a/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/utils/CompressorUtils.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/utils/CompressorUtils.kt
@@ -70,8 +70,9 @@ object CompressorUtils {
     inputFormat: MediaFormat,
     outputFormat: MediaFormat,
     newBitrate: Int,
+    targetFrameRate: Int,
   ) {
-    val newFrameRate = getFrameRate(inputFormat)
+    val newFrameRate = targetFrameRate.coerceAtLeast(1)
     val iFrameInterval = getIFrameIntervalRate(inputFormat)
     outputFormat.apply {
       setInteger(
@@ -105,12 +106,6 @@ object CompressorUtils {
         "videoFormat: $this"
       )
     }
-  }
-
-  // Get the frame rate from the input format or use a default value
-  private fun getFrameRate(format: MediaFormat): Int {
-    return if (format.containsKey(MediaFormat.KEY_FRAME_RATE)) format.getInteger(MediaFormat.KEY_FRAME_RATE)
-    else 30
   }
 
   // Get the I-frame (keyframe) interval from the input format or use a default value
@@ -172,7 +167,7 @@ object CompressorUtils {
   /**
    * Log an exception with a meaningful message.
    */
-  fun printException(exception: Exception) {
+  fun printException(exception: Throwable) {
     var message = "An error has occurred!"
     exception.localizedMessage?.let {
       message = it

--- a/android/src/main/java/com/reactnativecompressor/Video/VideoCompressorHelper.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/VideoCompressorHelper.kt
@@ -88,6 +88,16 @@ class VideoCompressorHelper {
             }
             return options
         }
+
+        fun getMetadataInt(metaRetriever: MediaMetadataRetriever, key: Int): Int {
+            return metaRetriever.extractMetadata(key)
+                ?.toDoubleOrNull()
+                ?.toLong()
+                ?.coerceIn(0L, Int.MAX_VALUE.toLong())
+                ?.toInt()
+                ?: 0
+        }
+
         fun VideoCompressManual(fileUrl: String?, options: VideoCompressorHelper, promise: Promise, reactContext: ReactApplicationContext?) {
             try {
                 val uri = Uri.parse(fileUrl)
@@ -95,24 +105,34 @@ class VideoCompressorHelper {
                 val destinationPath = Utils.generateCacheFilePath("mp4", reactContext!!)
                 val metaRetriever = MediaMetadataRetriever()
                 metaRetriever.setDataSource(srcPath)
-                var height = metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)!!.toInt()
-                var width = metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)!!.toInt()
-                val bitrate = metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_BITRATE)!!.toInt()
-                val isPortrait = height > width
-                val maxSize = options.maxSize.toInt()
-                if (isPortrait && height > maxSize) {
-                    width = (maxSize.toFloat() / height * width).toInt()
-                    height = maxSize
-                } else if (width > maxSize) {
-                    height = (maxSize.toFloat() / width * height).toInt()
-                    width = maxSize
-                } else {
-                    if (options.bitrate == 0f) {
-                        options.bitrate = (bitrate * 0.8).toInt().toFloat()
-                    }
+                val height = getMetadataInt(metaRetriever, MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
+                val width = getMetadataInt(metaRetriever, MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
+                val bitrate = getMetadataInt(metaRetriever, MediaMetadataRetriever.METADATA_KEY_BITRATE)
+                val frameRate = getMetadataInt(metaRetriever, MediaMetadataRetriever.METADATA_KEY_CAPTURE_FRAMERATE)
+                if (height <= 0 || width <= 0) {
+                    promise.reject(Throwable("Failed to read the input video dimensions"))
+                    return
                 }
-                val videoBitRate = if (options.bitrate > 0) options.bitrate else (height * width * 1.5).toFloat()
-                Utils.compressVideo(srcPath!!, destinationPath, width, height, videoBitRate, options.uuid!!,options.progressDivider!!, promise, reactContext)
+                val profile = VideoCompressionProfileFactory.createManual(
+                    sourceWidth = width,
+                    sourceHeight = height,
+                    sourceBitrate = bitrate,
+                    sourceFrameRate = frameRate,
+                    maxSize = options.maxSize,
+                    requestedBitrate = options.bitrate,
+                )
+                Utils.compressVideo(
+                    srcPath!!,
+                    destinationPath,
+                    profile.width,
+                    profile.height,
+                    profile.bitrate.toFloat(),
+                    profile.frameRate,
+                    options.uuid!!,
+                    options.progressDivider!!,
+                    promise,
+                    reactContext,
+                )
             } catch (ex: Exception) {
                 promise.reject(ex)
             }

--- a/ios/Video/VideoMain.swift
+++ b/ios/Video/VideoMain.swift
@@ -104,11 +104,11 @@ class VideoCompressor {
 
       VideoCompressor.getAbsoluteVideoPath(url.absoluteString, options: options) { absoluteVideoPath in
         var minimumFileSizeForCompress:Double=0.0;
-          let videoURL = URL(string: absoluteVideoPath)
+        let videoURL = URL(string: absoluteVideoPath)
         let fileSize=self.getfileSize(forURL: videoURL!);
-          if((options["minimumFileSizeForCompress"]) != nil)
-        {0
-              minimumFileSizeForCompress=options["minimumFileSizeForCompress"] as! Double;
+        if((options["minimumFileSizeForCompress"]) != nil)
+        {
+              minimumFileSizeForCompress=(options["minimumFileSizeForCompress"] as? NSNumber)?.doubleValue ?? 0;
         }
         if(fileSize>minimumFileSizeForCompress)
         {
@@ -146,55 +146,128 @@ class VideoCompressor {
 }
 
 
-    func  makeVideoBitrate(originalHeight:Int,originalWidth:Int,originalBitrate:Int,height:Int,width:Int)->Int {
-        let compressFactor:Float = 0.8
-        let  minCompressFactor:Float = 0.8
-        let maxBitrate:Int = 1669000
-        let minValue:Float=min(Float(originalHeight)/Float(height),Float(originalWidth)/Float(width))
-        var remeasuredBitrate:Int = Int(Float(originalBitrate) / minValue)
-        remeasuredBitrate = Int(Float(remeasuredBitrate)*compressFactor)
-        let minBitrate:Int = Int(Float(self.getVideoBitrateWithFactor(f: minCompressFactor)) / (1280 * 720 / Float(width * height)))
-        if (originalBitrate < minBitrate) {
-          return remeasuredBitrate;
+    struct CompressionProfile {
+        let width: Int
+        let height: Int
+        let bitrate: Int
+        let frameRate: Int
+    }
+
+    func normalizeDimension(_ value: CGFloat) -> Int {
+        let rounded = max(Int(value.rounded()), 2)
+        return rounded % 2 == 0 ? rounded : rounded - 1
+    }
+
+    func normalizeFrameRate(for track: AVAssetTrack) -> Int {
+        let nominalFrameRate = Int(track.nominalFrameRate.rounded())
+        if nominalFrameRate <= 0 {
+            return 30
         }
-        if (remeasuredBitrate > maxBitrate) {
-          return maxBitrate;
+
+        return min(max(nominalFrameRate, 1), 30)
+    }
+
+    func scaledDimensions(width: CGFloat, height: CGFloat, maxSize: CGFloat) -> (width: Int, height: Int) {
+        let safeWidth = normalizeDimension(width)
+        let safeHeight = normalizeDimension(height)
+        let longSide = max(safeWidth, safeHeight)
+        let safeMaxSize = max(Int(maxSize.rounded()), 2)
+
+        guard longSide > safeMaxSize else {
+            return (safeWidth, safeHeight)
         }
-        return max(remeasuredBitrate, minBitrate);
-      }
-    func getVideoBitrateWithFactor(f:Float)->Int {
-        return Int(f * 2000 * 1000 * 1.13);
-      }
+
+        let scale = CGFloat(safeMaxSize) / CGFloat(longSide)
+        return (
+            normalizeDimension(CGFloat(safeWidth) * scale),
+            normalizeDimension(CGFloat(safeHeight) * scale)
+        )
+    }
+
+    func estimateBitrate(
+        originalWidth: Int,
+        originalHeight: Int,
+        originalBitrate: Int,
+        originalFrameRate: Int,
+        targetWidth: Int,
+        targetHeight: Int,
+        targetFrameRate: Int
+    ) -> Int {
+        let targetLongSide = max(targetWidth, targetHeight)
+        let floor: Int
+        let ceiling: Int
+
+        switch targetLongSide {
+        case 1920...:
+            floor = 4_000_000
+            ceiling = 8_000_000
+        case 1280...1919:
+            floor = 2_200_000
+            ceiling = 5_000_000
+        case 960...1279:
+            floor = 1_600_000
+            ceiling = 3_500_000
+        case 720...959:
+            floor = 1_200_000
+            ceiling = 2_500_000
+        default:
+            floor = 850_000
+            ceiling = 1_500_000
+        }
+
+        guard originalBitrate > 0 else {
+            return floor
+        }
+
+        let originalPixels = max(originalWidth * originalHeight, 1)
+        let targetPixels = max(targetWidth * targetHeight, 1)
+        let pixelRatio = Double(targetPixels) / Double(originalPixels)
+        let safeOriginalFrameRate = max(originalFrameRate, 1)
+        let frameRateRatio = Double(targetFrameRate) / Double(safeOriginalFrameRate)
+        let scaledBitrate = Int((Double(originalBitrate) * pixelRatio * max(frameRateRatio, 0.85)).rounded())
+        let sourceCap = max(Int((Double(originalBitrate) * 0.95).rounded()), floor)
+        return min(max(scaledBitrate, floor), min(ceiling, sourceCap))
+    }
+
+    func createCompressionProfile(track: AVAssetTrack, maxSize: CGFloat, requestedBitrate: Int?) -> CompressionProfile {
+        let videoSize = track.naturalSize.applying(track.preferredTransform)
+        let actualWidth = abs(videoSize.width)
+        let actualHeight = abs(videoSize.height)
+        let dimensions = scaledDimensions(width: actualWidth, height: actualHeight, maxSize: maxSize)
+        let frameRate = normalizeFrameRate(for: track)
+        let sourceFrameRate = Int(track.nominalFrameRate.rounded())
+        let bitrate = requestedBitrate ?? estimateBitrate(
+            originalWidth: normalizeDimension(actualWidth),
+            originalHeight: normalizeDimension(actualHeight),
+            originalBitrate: Int(abs(track.estimatedDataRate.rounded())),
+            originalFrameRate: sourceFrameRate,
+            targetWidth: dimensions.width,
+            targetHeight: dimensions.height,
+            targetFrameRate: frameRate
+        )
+
+        return CompressionProfile(
+            width: dimensions.width,
+            height: dimensions.height,
+            bitrate: max(bitrate, 1),
+            frameRate: frameRate
+        )
+    }
 
     func autoCompressionHelper(url: URL, options: [String: Any], onProgress: @escaping (Float) -> Void,  onCompletion: @escaping (URL) -> Void, onFailure: @escaping (Error) -> Void){
-        let maxSize:Float = options["maxSize"] as! Float;
+        let maxSize = (options["maxSize"] as? NSNumber)?.floatValue ?? 640
         let uuid:String = options["uuid"] as! String
         let progressDivider=options["progressDivider"] as? Int ?? 0
 
         let asset = AVAsset(url: url)
-        guard asset.tracks.count >= 1 else {
+        guard let track = getVideoTrack(asset: asset) else {
           let error = CompressionError(message: "Invalid video URL, no track found")
           onFailure(error)
           return
         }
-        let track = getVideoTrack(asset: asset);
+        let profile = createCompressionProfile(track: track, maxSize: CGFloat(maxSize), requestedBitrate: nil)
 
-        let videoSize = track.naturalSize.applying(track.preferredTransform);
-        let actualWidth = Float(abs(videoSize.width))
-        let actualHeight = Float(abs(videoSize.height))
-
-        let bitrate=Float(abs(track.estimatedDataRate));
-        let scale:Float = actualWidth > actualHeight ? (Float(maxSize) / actualWidth) : (Float(maxSize) / actualHeight);
-        let resultWidth:Float = round(actualWidth * min(scale, 1) / 2) * 2;
-        let resultHeight:Float = round(actualHeight * min(scale, 1) / 2) * 2;
-
-        let videoBitRate:Int = self.makeVideoBitrate(
-            originalHeight: Int(actualHeight), originalWidth: Int(actualWidth),
-            originalBitrate: Int(bitrate),
-            height: Int(resultHeight), width: Int(resultWidth)
-            );
-
-        exportVideoHelper(url: url, asset: asset, bitRate: videoBitRate, resultWidth: resultWidth, resultHeight: resultHeight,uuid: uuid,progressDivider: progressDivider) { progress in
+        exportVideoHelper(url: url, asset: asset, bitRate: profile.bitrate, frameRate: profile.frameRate, resultWidth: profile.width, resultHeight: profile.height,uuid: uuid,progressDivider: progressDivider) { progress in
             onProgress(progress)
         } onCompletion: { outputURL in
             onCompletion(outputURL)
@@ -205,36 +278,18 @@ class VideoCompressor {
 
     func manualCompressionHelper(url: URL, options: [String: Any], onProgress: @escaping (Float) -> Void,  onCompletion: @escaping (URL) -> Void, onFailure: @escaping (Error) -> Void){
         let uuid:String = options["uuid"] as! String
-        var bitRate = (options["bitrate"] as? NSNumber)?.floatValue;
+        let bitRate = (options["bitrate"] as? NSNumber)?.intValue
         let progressDivider=options["progressDivider"] as? Int ?? 0
         let asset = AVAsset(url: url)
-        guard asset.tracks.count >= 1 else {
+        guard let track = getVideoTrack(asset: asset) else {
           let error = CompressionError(message: "Invalid video URL, no track found")
           onFailure(error)
           return
         }
-        let track = getVideoTrack(asset: asset);
+        let maxSize = (options["maxSize"] as? NSNumber)?.floatValue ?? Float(1920)
+        let profile = createCompressionProfile(track: track, maxSize: CGFloat(maxSize), requestedBitrate: bitRate)
 
-        let videoSize = track.naturalSize.applying(track.preferredTransform);
-        var width = Float(abs(videoSize.width))
-        var height = Float(abs(videoSize.height))
-        let isPortrait = height > width
-        let maxSize = (options["maxSize"] as! Float?) ?? Float(1920);
-        if(isPortrait && height > maxSize){
-          width = (maxSize/height)*width
-          height = maxSize
-        }else if(width > maxSize){
-          height = (maxSize/width)*height
-          width = maxSize
-        }
-        else
-        {
-            bitRate=bitRate ?? Float(abs(track.estimatedDataRate))*0.8
-        }
-
-        let videoBitRate = bitRate ?? height*width*1.5
-
-        exportVideoHelper(url: url, asset: asset, bitRate: Int(videoBitRate), resultWidth: width, resultHeight: height,uuid: uuid,progressDivider: progressDivider) { progress in
+        exportVideoHelper(url: url, asset: asset, bitRate: profile.bitrate, frameRate: profile.frameRate, resultWidth: profile.width, resultHeight: profile.height,uuid: uuid,progressDivider: progressDivider) { progress in
             onProgress(progress)
         } onCompletion: { outputURL in
             onCompletion(outputURL)
@@ -243,7 +298,7 @@ class VideoCompressor {
         }
       }
 
-    func exportVideoHelper(url: URL,asset: AVAsset, bitRate: Int,resultWidth:Float,resultHeight:Float,uuid:String,progressDivider: Int, onProgress: @escaping (Float) -> Void,  onCompletion: @escaping (URL) -> Void, onFailure: @escaping (Error) -> Void){
+    func exportVideoHelper(url: URL,asset: AVAsset, bitRate: Int, frameRate: Int, resultWidth:Int,resultHeight:Int,uuid:String,progressDivider: Int, onProgress: @escaping (Float) -> Void,  onCompletion: @escaping (URL) -> Void, onFailure: @escaping (Error) -> Void){
         var currentVideoCompression:Int=0
 
         var tmpURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
@@ -258,13 +313,15 @@ class VideoCompressor {
         let compressionDict: [String: Any] = [
           AVVideoAverageBitRateKey: bitRate,
           AVVideoProfileLevelKey: AVVideoProfileLevelH264HighAutoLevel,
+          AVVideoExpectedSourceFrameRateKey: frameRate,
+          AVVideoAverageNonDroppableFrameRateKey: frameRate,
         ]
         exporter.optimizeForNetworkUse = true;
         exporter.videoOutputConfiguration = [
           AVVideoCodecKey: AVVideoCodecType.h264,
           AVVideoWidthKey:  resultWidth,
           AVVideoHeightKey:  resultHeight,
-          AVVideoScalingModeKey: AVVideoScalingModeResizeAspectFill,
+          AVVideoScalingModeKey: AVVideoScalingModeResizeAspect,
           AVVideoCompressionPropertiesKey: compressionDict
         ]
         exporter.audioOutputConfiguration = [
@@ -284,6 +341,7 @@ class VideoCompressor {
             }
         }, completionHandler: { result in
             currentVideoCompression=0;
+            self.compressorExports[uuid] = nil
             switch exporter.status {
             case .completed:
               onCompletion(exporter.outputURL!)
@@ -293,14 +351,17 @@ class VideoCompressor {
                 onFailure(error)
                 break
             default:
-                onCompletion(url)
+                onFailure(exporter.error ?? CompressionError(message: "Compression failed"))
               break
           }
         })
     }
 
-    func getVideoTrack(asset: AVAsset) -> AVAssetTrack {
+    func getVideoTrack(asset: AVAsset) -> AVAssetTrack? {
         let tracks = asset.tracks(withMediaType: AVMediaType.video)
+        guard tracks.count >= 1 else {
+            return nil
+        }
         return tracks[0];
         }
 

--- a/ios/Video/VideoMain.swift
+++ b/ios/Video/VideoMain.swift
@@ -236,7 +236,7 @@ class VideoCompressor {
         let dimensions = scaledDimensions(width: actualWidth, height: actualHeight, maxSize: maxSize)
         let frameRate = normalizeFrameRate(for: track)
         let sourceFrameRate = Int(track.nominalFrameRate.rounded())
-        let bitrate = requestedBitrate ?? estimateBitrate(
+        let bitrate = (requestedBitrate != nil && requestedBitrate! > 0) ? requestedBitrate! : estimateBitrate(
             originalWidth: normalizeDimension(actualWidth),
             originalHeight: normalizeDimension(actualHeight),
             originalBitrate: Int(abs(track.estimatedDataRate.rounded())),


### PR DESCRIPTION
This PR adds an audited upstream issue triage document and targets the recurring video compression failures reported for large/high-resolution inputs, especially 4k media. It also folds in a small set of native fixes that were directly verifiable while reviewing those reports.

- **Upstream issue triage**
  - Adds `TRIAGE.md` with a pass over upstream open issues.
  - Classifies reports as real issues, duplicates, stale/obsolete, feature requests, or needing more information.
  - Groups the repeated Android video-compression reports into a common failure cluster to make follow-up work easier to prioritize.

- **Android video compression profile**
  - Replaces the previous fixed-cap bitrate behavior with an adaptive compression profile based on source dimensions, bitrate, and frame rate.
  - Normalizes output dimensions to valid even-numbered sizes before transcoding.
  - Caps target frame rate for heavy inputs to reduce encoder pressure on 4k sources.
  - Rejects invalid/tiny output artifacts instead of reporting success on broken files.

- **iOS video compression profile**
  - Aligns iOS sizing and bitrate selection with the new adaptive profile used for Android.
  - Switches scaling to aspect-preserving output settings.
  - Propagates compression failures instead of silently falling back to the original file on exporter errors.

- **Minor native fixes**
  - Guards iOS video-track lookup so audio-only MP4 inputs fail cleanly instead of crashing.
  - Clamps Android metadata parsing so extreme/invalid bitrate metadata cannot overflow native integer conversion.
  - Enables Android `buildConfig` generation for AGP 8+ compatibility.

Example usage remains the same; the change is in how native compression profiles are derived for high-resolution inputs:

```ts
const result = await Video.compress(uri, {
  compressionMethod: 'auto',
  maxSize: 1080,
  minimumFileSizeForCompress: 15,
});
```

With this PR, that path now uses normalized dimensions, adaptive bitrate selection, and safer native failure handling instead of the older static heuristics.

@numandev1 Please have a look at these minimal changes. Should help with lowering reported issues..