### PR TITLE
fix: blacklist QTI AVC encoder's legacy OMX alias in pickAvcEncoder

### DIFF
--- a/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/compressor/Compressor.kt
+++ b/android/src/main/java/com/reactnativecompressor/Video/VideoCompressor/compressor/Compressor.kt
@@ -734,8 +734,12 @@ object Compressor {
         }
 
         fun isBlacklisted(name: String): Boolean {
+            // ALL_CODECS also surfaces the legacy OMX alias of the QTI encoder
+            // (OMX.qcom.video.encoder.avc). createByCodecName resolves the alias
+            // back to c2.qti.avc.encoder, so it must be blacklisted under both
+            // names. The shorter needle also covers the ".secure" variant.
             val lower = name.lowercase()
-            return lower.contains("c2.qti.avc.encoder") || lower.contains("omx.qcom.video.encoder.avc.secure")
+            return lower.contains("c2.qti.avc.encoder") || lower.contains("omx.qcom.video.encoder.avc")
         }
 
         fun isSoftware(info: MediaCodecInfo): Boolean {


### PR DESCRIPTION
`pickAvcEncoder` enumerates `MediaCodecList(ALL_CODECS)`, which surfaces **legacy OMX aliases** alongside Codec2 names. On Snapdragon devices the blacklisted `c2.qti.avc.encoder` is also advertised as `OMX.qcom.video.encoder.avc` — that alias passes the c2-only blacklist check, wins the hardware-first preference, and `createByCodecName` resolves it right back to the blacklisted component. So every compression on Qualcomm devices runs on the encoder the blacklist exists to avoid.

Observed in production (family photo app): on Samsung One UI 8 / Android 16 (Galaxy S21→S25) the encoder dies ~80 ms after `start()` — logcat: `CCodec: Component "c2.qti.avc.encoder" returned error: 0xffffffff` at the first input-surface dataspace change — surfacing to JS as `IllegalStateException: Invalid to call at Released state` from `dequeueOutputBuffer` (`Compressor.kt:394`). Likely related to #409. On devices where the encoder survives, output runs through the codec originally blacklisted for producing files unplayable on Mac/iOS.

**Fix:** match the alias in the blacklist (`contains` covers the `.secure` variant too). Selection then falls to `c2.android.avc.encoder` on QTI devices — the pre-2.x behavior. Non-Qualcomm devices are unaffected.

**Verified on a physical Galaxy S23 (SM-S911U1, Android 16 / One UI 8.0), same source clip:**

| build | log | outcome |
|---|---|---|
| before | `encoder selected: OMX.qcom.video.encoder.avc` | instant failure, 3/3 attempts |
| after | `encoder selected: c2.android.avc.encoder` | clean transcode, every attempt |

Logcat excerpts of the full codec death sequence available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)